### PR TITLE
Add example of source quoting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ The following features of dbt are not implemented on Athena:
 #### Known issues
 
 * Quoting is not currently supported
+  * If you need to quote your sources, escape the quote characters in your source definitions:
+  
+  ```yaml
+  version: 2
+
+  sources:
+    - name: my_source
+      tables:
+        - name: first_table
+          identifier: "first table"       # Not like that
+        - name: second_table
+          idenfitier: "\"second table\""  # Like this
+  ```
+
 * Tables, schemas and database should only be lowercase
 * **Only** supports Athena engine 2
   * [Changing Athena Engine Versions][engine-change]


### PR DESCRIPTION
@Tomme as discussed previously, I took a look at the quoting issue and probably arrived at the same conclusion as you when you initially decided not to spend time on it. Here's the gist as I understand it:

* Athena uses Presto for DML queries and Hive for DDL queries
* Presto uses double quotes ( " ) for quoting identifiers whereas Hive uses backticks ( \` )

In order for the adapter to support quoting it would have to be able to distinguish between DDL and DML statements and then pass that information on to the methods that handle quoting (e.g., `AthenaRelation.quoted`, `AthenaAdapter.quote`). This in turn requires overloading of the quoting methods which is simple enough but we'd also need to overload quite a lot of existing macros that call these methods. It might be worth the initial effort but maintaining the overloaded macros could turn into a nightmare. 

Instead of fixing the quoting issue I added an example source quoting in `README.md`.

## Examples

Hive DDL:

```sql
create external table if not exists `"user 123"` (
    id int,
    name varchar(255)
)
location 's3://athena-query-results/user/'
```

Presto DML:

```sql
insert into "user 123" (id, name)
values (1, 'test user')
```