### PR TITLE
Add optional aws_profile_name to adapter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Notes:
 ### Credentials
 
 This plugin does not accept any credentials directly. Instead, [credentials are determined automatically](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) based on `aws cli`/`boto3` conventions and
-stored login info.
+stored login info. You can configure the AWS profile name to use via `aws_profile_name`. Checkout DBT profile configuration below for details.
 
 ### Configuring your profile
 
@@ -48,6 +48,7 @@ A dbt profile can be configured to run against AWS Athena using the following co
 | schema          | Specify the schema (Athena database) to build models into (lowercase **only**)  | Required   | `dbt`               |
 | database        | Specify the database (Data catalog) to build models into (lowercase **only**)   | Required   | `awsdatacatalog`    |
 | poll_interval   | Interval in seconds to use for polling the status of query results in Athena    | Optional   | `5`                 |
+| aws_profile_name| Profile to use from your AWS shared credentials file.                           | Optional   | `my-profile`        |
 
 **Example profiles.yml entry:**
 ```yaml
@@ -60,6 +61,7 @@ athena:
       region_name: eu-west-1
       schema: dbt
       database: awsdatacatalog
+      aws_profile_name: my-profile
 ```
 
 _Additional information_

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -27,6 +27,7 @@ class AthenaCredentials(Credentials):
     region_name: str
     schema: str
     work_group: Optional[str]
+    aws_profile_name: Optional[str]
     poll_interval: float = 1.0
     _ALIASES = {
         "catalog": "database"
@@ -38,7 +39,7 @@ class AthenaCredentials(Credentials):
         return "athena"
 
     def _connection_keys(self) -> Tuple[str, ...]:
-        return "s3_staging_dir", "work_group", "region_name", "database", "schema", "poll_interval"
+        return "s3_staging_dir", "work_group", "region_name", "database", "schema", "poll_interval", "aws_profile_name"
 
 
 class AthenaCursor(Cursor):
@@ -115,6 +116,7 @@ class AthenaConnectionManager(SQLConnectionManager):
                 cursor_class=AthenaCursor,
                 formatter=AthenaParameterFormatter(),
                 poll_interval=creds.poll_interval,
+                profile_name=creds.aws_profile_name
             )
 
             connection.state = "open"


### PR DESCRIPTION
Let me start by saying thanks for the amazing work on the adapter. Really enjoying it!

This PR allows pointing a DBT profile to a specific AWS profile without managing the AWS_PROFILE environment variable separately.

Example: consider a situation where I want to run the same DBT project against different AWS accounts (e.g. `dev`, `prd`). For both accounts I have credentials in my `~/.aws/credentials` file in different profiles (e.g. `[dev]` and `[prd]`). Currently, I have to run `export AWS_PROFILE=<profile_name>` before starting my `dbt run` to make this work, which is very error-prone.