### PR TITLE
Make retry config a configurable, add InternalServerException

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ A dbt profile can be configured to run against AWS Athena using the following co
 | database        | Specify the database (Data catalog) to build models into (lowercase **only**)   | Required   | `awsdatacatalog`    |
 | poll_interval   | Interval in seconds to use for polling the status of query results in Athena    | Optional   | `5`                 |
 | aws_profile_name| Profile to use from your AWS shared credentials file.                           | Optional   | `my-profile`        |
+| work_group| Identifier of Athena workgroup   | Optional   | `my-custom-workgroup`        |
+| num_retries| Number of times to retry a failing query | Optional  | `3`  | `5`
 
 **Example profiles.yml entry:**
 ```yaml


### PR DESCRIPTION
* Add `num_retries` option to pass to `RetryConfig`
* Add `InternalServerException`-> lately Athena also seems to map throttling errors to this exception
* Document missing `work_group` parameter