### PR TITLE
Implement retry for query execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dbt-core==0.21.0
 pyathena==2.2.0
 boto3==1.18.12
+tenacity==6.3.1


### PR DESCRIPTION
Pyathena only retries on exceptions in the API, but not failed queries (e.g. ones that failed to execute because of exhausted resources).

This change allows the adapter to retry executing the query the configured amount of times.
