### PR TITLE
Avoid clean up of table when incremental_strategy is not insert_overwrite

### DIFF
--- a/dbt/include/athena/macros/adapters.sql
+++ b/dbt/include/athena/macros/adapters.sql
@@ -110,7 +110,9 @@
 {% endmacro %}
 
 {% macro athena__drop_relation(relation) -%}
-  {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
+  {% if config.get('incremental_strategy') == 'insert_overwrite' %}
+    {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
+  {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}
     drop {{ relation.type }} if exists {{ relation }}
   {%- endcall %}


### PR DESCRIPTION
This once in a while can fail, because of failing API calls (a too high request rate to S3).

This change also might improve performance a bit - as the API calls to Glue / S3 in between executing queries is reduced for normal views/table models.