### PR TITLE
Use unique temporary table name + Check schema change

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,17 @@ stored login info. You can configure the AWS profile name to use via `aws_profil
 
 A dbt profile can be configured to run against AWS Athena using the following configuration:
 
-| Option          | Description                                                                     | Required?  | Example             |
-|---------------- |-------------------------------------------------------------------------------- |----------- |-------------------- |
-| s3_staging_dir  | S3 location to store Athena query results and metadata                          | Required   | `s3://bucket/dbt/`  |
-| region_name     | AWS region of your Athena instance                                              | Required   | `eu-west-1`         |
-| schema          | Specify the schema (Athena database) to build models into (lowercase **only**)  | Required   | `dbt`               |
-| database        | Specify the database (Data catalog) to build models into (lowercase **only**)   | Required   | `awsdatacatalog`    |
-| poll_interval   | Interval in seconds to use for polling the status of query results in Athena    | Optional   | `5`                 |
-| aws_profile_name| Profile to use from your AWS shared credentials file.                           | Optional   | `my-profile`        |
-| work_group| Identifier of Athena workgroup   | Optional   | `my-custom-workgroup`        |
+| Option          | Description                                                                     | Required?  | Example               |
+|---------------- |-------------------------------------------------------------------------------- |----------- |-----------------------|
+| s3_staging_dir  | S3 location to store Athena query results and metadata                          | Required   | `s3://bucket/dbt/`    |
+| region_name     | AWS region of your Athena instance                                              | Required   | `eu-west-1`           |
+| schema          | Specify the schema (Athena database) to build models into (lowercase **only**)  | Required   | `dbt`                 |
+| database        | Specify the database (Data catalog) to build models into (lowercase **only**)   | Required   | `awsdatacatalog`      |
+| poll_interval   | Interval in seconds to use for polling the status of query results in Athena    | Optional   | `5`                   |
+| aws_profile_name| Profile to use from your AWS shared credentials file.                           | Optional   | `my-profile`          |
+| work_group      | Identifier of Athena workgroup                                                  | Optional   | `my-custom-workgroup` |
 | num_retries| Number of times to retry a failing query | Optional  | `3`  | `5`
+
 
 **Example profiles.yml entry:**
 ```yaml

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -39,7 +39,6 @@ class AthenaAdapter(SQLAdapter):
     def s3_uuid_table_location(self):
         conn = self.connections.get_thread_connection()
         client = conn.handle
-
         return f"{client.s3_staging_dir}tables/{str(uuid4())}/"
 
     @available
@@ -69,6 +68,10 @@ class AthenaAdapter(SQLAdapter):
                 s3_bucket.objects.filter(Prefix=prefix).delete()
 
     @available
+    def unique_temp_table_suffix(self, suffix_initial="__dbt_tmp", length=8):
+        return f"{suffix_initial}_{str(uuid4())[:length]}"
+
+    @available
     def clean_up_table(
         self, database_name: str, table_name: str
     ):
@@ -96,4 +99,3 @@ class AthenaAdapter(SQLAdapter):
                 s3_resource = boto3.resource('s3', region_name=client.region_name)
                 s3_bucket = s3_resource.Bucket(bucket_name)
                 s3_bucket.objects.filter(Prefix=prefix).delete()
-


### PR DESCRIPTION
Changes in this PR:

- Add ability to create unique temporary table names. This would enable running multiple `dbt run` concurrently for incremental model.
- Implement `fail_fast` mode when schema changes