### PR TITLE
Support s3_data_dir and s3_data_naming

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -40,6 +40,8 @@ class AthenaCredentials(Credentials):
     poll_interval: float = 1.0
     _ALIASES = {"catalog": "database"}
     num_retries: Optional[int] = 5
+    s3_data_dir: Optional[str] = None
+    s3_data_naming: Optional[str] = "uuid"
 
     @property
     def type(self) -> str:

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -12,6 +12,8 @@
     with (
       {%- if external_location is not none and not temporary %}
         external_location='{{ external_location }}',
+      {%- elif adapter.has_s3_data_dir() -%}
+        external_location='{{ adapter.s3_table_location(relation.schema, relation.identifier) }}',
       {%- endif %}
       {%- if partitioned_by is not none %}
         partitioned_by=ARRAY{{ partitioned_by | tojson | replace('\"', '\'') }},

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -21,7 +21,7 @@
         {%- endfor -%}
     )
     stored as parquet
-    location '{{ adapter.s3_uuid_table_location() }}'
+    location '{{ adapter.s3_table_location(model["schema"], model["alias"]) }}'
     tblproperties ('classification'='parquet')
   {% endset %}
 


### PR DESCRIPTION
## Problem

Currently, the only options for determining where data ends up in S3 are to set `s3_staging_bucket` in the connection properties or set `external_location` on each model.

The `s3_staging_bucket` argument is ignored if the Athena workgroup already has a staging bucket configured (but is used by `dbt seed`, which always sets a location).

We have a (not uncommon?) layout of one S3 bucket for the results of all Athena queries from which objects are rapidly expired, and another with appropriate lifecycle configuration for storing created tables we want to keep.

Aside from setting `external_location` on every model (which isn't so easily composable across different profiles), there isn't a nice way to control S3 layout in `dbt-athena` as it stands.

## Implementation

This adds two new (optional) connection options:

* `s3_data_dir`: if set, the default root directory to create tables and seeds in (eg, `s3://my-data-bucket/dbt/`)
* `s3_data_naming`: the strategy for naming subdirectories of `s3_data_dir` in which we'll actually store tables; two implemented options:
  + `uuid`: tables or seeds are saved to `{s3_data_dir}/{uuid4}/` (this was how seed tables were already named) 
  + `schema_table`: name according to the schema (ie, Athena database) and table like `{s3_data_dir}/{schema}/{table}/`

If `s3_data_dir` is unset, the behaviour should be unchanged:

* Seed tables are saved to `{s3_staging_dir}/tables/{uuid4}/`
* Tables are saved to `external_location` if set, and Athena's default otherwise.