### PR TITLE
Remove failing `alter table` when creating a view

### DIFF
--- a/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
@@ -23,9 +23,6 @@
     {{ create_view_as(target_relation, sql) }}
   {%- endcall %}
 
-  -- set table properties
-  {{ set_table_classification(target_relation, 'view') }}
-
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {{ adapter.commit() }}


### PR DESCRIPTION
The `alter table` statement can not be executed on a view. It will fail
with the runtime error, `FAILED: SemanticException [Error 10131]: To
alter a view you need to use the ALTER VIEW command.`.

There is no documentation for `alter view`, and if you run a query like
`alter view "db.view" set tblproperties ('classification' = 'view')`, it
will fail with the syntax error, `line 1:7: mismatched input 'view'.
Expecting: 'SCHEMA', 'TABLE'`.

Everything appears to work just fine when this `alter table` statement
is not run, therefore I've removed the macro, which executes the `alter
table` statement from the view creation macro.