### PR TITLE
resolve #54 clean up all dbt models except those materialised as incremental with append strategy

### DIFF
--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,5 +1,5 @@
 {% macro athena__drop_relation(relation) -%}
-  {% if config.get('incremental_strategy') == 'insert_overwrite' %}
+  {% if config.get('incremental_strategy') != 'append' %}
     {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
   {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}


### PR DESCRIPTION
Resolves #54

Currently, any tables that have a static external_location and are materialised as a table rather than incremental fail due to the underlying data not being cleaned up.

This is a minor fix to specify that only incremental tables that use the `append` approach are not cleaned up.