### PR TITLE
Support large DBs for dbt docs

### DIFF
--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
+from typing import Dict, Set, Optional
 
-from dbt.adapters.base.relation import BaseRelation, Policy
+from dbt.adapters.base.relation import BaseRelation, Policy, InformationSchema
 
 
 @dataclass
@@ -14,3 +15,20 @@ class AthenaIncludePolicy(Policy):
 class AthenaRelation(BaseRelation):
     quote_character: str = ""
     include_policy: Policy = AthenaIncludePolicy()
+
+class AthenaSchemaSearchMap(Dict[InformationSchema, Dict[str, Set[Optional[str]]]]):
+    """A utility class to keep track of what information_schema tables to
+    search for in databases. The schema and tables values are all lowercased to 
+    avoid duplication.
+    """
+    def add(self, relation: AthenaRelation):
+        key = relation.information_schema_only()
+        if key not in self:
+            self[key] = {}
+        schema: Optional[str] = None
+        if relation.schema is not None:
+            schema = relation.schema.lower()
+            table_schema = relation.name.lower()
+            if schema not in self[key]:
+                self[key][schema] = set()
+            self[key][schema].add(table_schema)


### PR DESCRIPTION
fixes https://github.com/Tomme/dbt-athena/issues/79

## Overview

Currently the `athena__get_catalog` macro query hangs indefinitely when trying to generate docs for a database with more than 100 tables, these changes fix the issue by specifying which tables to fetch per each database and batches to a maximum of 100 tables.

## What's changed

It overrides the default `BaseAdapter._get_catalog_schemas()` function with a custom `AthenaAdapter._get_catalog_schemas()`, which instead of using `SchemaSearchMap` now uses a custom `AthenaSchemaSearchMap`.
The `SchemaSearchMap.add()` only returns a dictionary with values being a set of database names, the new `AthenaSchemaSearchMap.add()` returns a dictionary of dictionaries, where each dictionary key is a database name and the value is a set of the tables in the database.

Using the new `AthenaSchemaSearchMap` the `athena__get_catalog` macro now batches the queries to do a maximum select of 100 tables per database per each union.

