### PR TITLE
[BUGFIX] Handle AWS API Error while deleting S3 objects

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -75,12 +75,13 @@ class AthenaAdapter(SQLAdapter):
                 s3_bucket = s3_resource.Bucket(bucket_name)
                 s3_bucket.objects.filter(Prefix=prefix).delete()
                 response = s3_bucket.objects.filter(Prefix=prefix).delete()
-                # response is empty if there is no error.
-                if len(response) != 0:
-                    for res in response:
-                        if "Errors" in res:
-                            for err in res["Errors"]:
-                                logger.error("Failed to clean up partitions caused by failure in S3 object Key='{}', Code='{}', Message='{}', s3_bucket_name='{}'", err["Key"], err["Code"], err["Message"], bucket_name)
+                is_all_successful = True
+                for res in response:
+                    if "Errors" in res:
+                        for err in res["Errors"]:
+                            is_all_successful = False
+                            logger.error("Failed to clean up partitions caused by failure in S3 object Key='{}', Code='{}', Message='{}', s3_bucket_name='{}'", err["Key"], err["Code"], err["Message"], bucket_name)
+                if is_all_successful is False:
                     raise RuntimeException("Failed to clean up table partitions.")
 
     @available


### PR DESCRIPTION
This change prevents having duplicated data in a table ( incremental, insert_overwrite, partition ) that can be caused by missing permission.

Fixes #85 