### PR TITLE
Support PyAthena above version 2.6.*

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -218,6 +218,9 @@ class AthenaParameterFormatter(Formatter):
         ):
             escaper = _escape_presto
         else:
+            # Fixes ParseException that comes with newer version of PyAthena
+            operation = operation.replace("\n\n    ", "\n")
+
             escaper = _escape_hive
 
         kwargs: Optional[List[str]] = None


### PR DESCRIPTION
- Fixes the `ParseException` raised by newer versions of PyAthena

- All integration tests passed