### PR TITLE
Respect configured AWS profile when calling boto3

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -1,3 +1,4 @@
+import boto3
 from typing import ContextManager, Tuple, Optional, List, Dict, Any
 from dataclasses import dataclass
 from contextlib import contextmanager
@@ -140,13 +141,11 @@ class AthenaConnectionManager(SQLConnectionManager):
             handle = AthenaConnection(
                 s3_staging_dir=creds.s3_staging_dir,
                 endpoint_url=creds.endpoint_url,
-                region_name=creds.region_name,
                 schema_name=creds.schema,
                 work_group=creds.work_group,
                 cursor_class=AthenaCursor,
                 formatter=AthenaParameterFormatter(),
                 poll_interval=creds.poll_interval,
-                profile_name=creds.aws_profile_name,
                 retry_config=RetryConfig(
                     attempt=creds.num_retries,
                     exceptions=(
@@ -154,6 +153,10 @@ class AthenaConnectionManager(SQLConnectionManager):
                         "TooManyRequestsException",
                         "InternalServerException",
                     ),
+                ),
+                session=boto3.session.Session(
+                    profile_name=creds.aws_profile_name,
+                    region_name=creds.region_name,
                 ),
             )
 

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1,6 +1,5 @@
 import agate
 import re
-import boto3
 from botocore.exceptions import ClientError
 from itertools import chain
 from threading import Lock
@@ -61,8 +60,8 @@ class AthenaAdapter(SQLAdapter):
         client = conn.handle
 
         with boto3_client_lock:
-            glue_client = boto3.client('glue', region_name=client.region_name)
-        s3_resource = boto3.resource('s3', region_name=client.region_name)
+            glue_client = client.session.client('glue')
+        s3_resource = client.session.resource('s3')
         partitions = glue_client.get_partitions(
             # CatalogId='123456789012', # Need to make this configurable if it is different from default AWS Account ID
             DatabaseName=database_name,
@@ -87,7 +86,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
         with boto3_client_lock:
-            glue_client = boto3.client('glue', region_name=client.region_name)
+            glue_client = client.session.client('glue')
         try:
             table = glue_client.get_table(
                 DatabaseName=database_name,
@@ -105,7 +104,7 @@ class AthenaAdapter(SQLAdapter):
             if m is not None:
                 bucket_name = m.group(1)
                 prefix = m.group(2)
-                s3_resource = boto3.resource('s3', region_name=client.region_name)
+                s3_resource = client.session.resource('s3')
                 s3_bucket = s3_resource.Bucket(bucket_name)
                 s3_bucket.objects.filter(Prefix=prefix).delete()
 
@@ -152,7 +151,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
         with boto3_client_lock:
-            athena_client = boto3.client('athena', region_name=client.region_name)
+            athena_client = client.session.client('athena')
         
         response = athena_client.get_data_catalog(Name=catalog_name)
         return response['DataCatalog']
@@ -172,7 +171,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
         with boto3_client_lock:
-            glue_client = boto3.client('glue', region_name=client.region_name)
+            glue_client = client.session.client('glue')
         paginator = glue_client.get_paginator('get_tables')
 
         kwargs = {


### PR DESCRIPTION
Use a shared `boto3.session.Session` between `pyathena` and manual
`boto3` calls. This fixes #120