### PR TITLE
#56 #121 #124: Initializes boto3 session globally to support configured AWS profile when calling boto3

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -21,6 +21,7 @@ from dbt.contracts.connection import Connection, AdapterResponse
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.exceptions import RuntimeException, FailedToConnectException
 from dbt.events import AdapterLogger
+from dbt.adapters.athena.session import get_boto3_session
 
 import tenacity
 from tenacity.retry import retry_if_exception
@@ -140,13 +141,12 @@ class AthenaConnectionManager(SQLConnectionManager):
             handle = AthenaConnection(
                 s3_staging_dir=creds.s3_staging_dir,
                 endpoint_url=creds.endpoint_url,
-                region_name=creds.region_name,
                 schema_name=creds.schema,
                 work_group=creds.work_group,
                 cursor_class=AthenaCursor,
                 formatter=AthenaParameterFormatter(),
                 poll_interval=creds.poll_interval,
-                profile_name=creds.aws_profile_name,
+                session=get_boto3_session(connection),
                 retry_config=RetryConfig(
                     attempt=creds.num_retries,
                     exceptions=(

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1,6 +1,5 @@
 import agate
 import re
-import boto3
 from botocore.exceptions import ClientError
 from itertools import chain
 from threading import Lock
@@ -59,10 +58,9 @@ class AthenaAdapter(SQLAdapter):
         # Look up Glue partitions & clean up
         conn = self.connections.get_thread_connection()
         client = conn.handle
-
         with boto3_client_lock:
-            glue_client = boto3.client('glue', region_name=client.region_name)
-        s3_resource = boto3.resource('s3', region_name=client.region_name)
+            glue_client = client.session.client('glue')
+            s3_resource = client.session.resource('s3')
         partitions = glue_client.get_partitions(
             # CatalogId='123456789012', # Need to make this configurable if it is different from default AWS Account ID
             DatabaseName=database_name,
@@ -87,7 +85,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
         with boto3_client_lock:
-            glue_client = boto3.client('glue', region_name=client.region_name)
+            glue_client = client.session.client('glue')
         try:
             table = glue_client.get_table(
                 DatabaseName=database_name,
@@ -105,7 +103,7 @@ class AthenaAdapter(SQLAdapter):
             if m is not None:
                 bucket_name = m.group(1)
                 prefix = m.group(2)
-                s3_resource = boto3.resource('s3', region_name=client.region_name)
+                s3_resource = client.session.resource('s3')
                 s3_bucket = s3_resource.Bucket(bucket_name)
                 s3_bucket.objects.filter(Prefix=prefix).delete()
 
@@ -152,7 +150,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
         with boto3_client_lock:
-            athena_client = boto3.client('athena', region_name=client.region_name)
+            athena_client = client.session.client('athena')
         
         response = athena_client.get_data_catalog(Name=catalog_name)
         return response['DataCatalog']
@@ -172,7 +170,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
         with boto3_client_lock:
-            glue_client = boto3.client('glue', region_name=client.region_name)
+            glue_client = client.session.client('glue')
         paginator = glue_client.get_paginator('get_tables')
 
         kwargs = {

--- a/dbt/adapters/athena/session.py
+++ b/dbt/adapters/athena/session.py
@@ -5,7 +5,7 @@ from dbt.contracts.connection import Connection
 __BOTO3_SESSION__: boto3.session.Session = None
 
 
-def get_boto3_session(connection: Connection) -> boto3.session.Session:
+def get_boto3_session(connection: Connection = None) -> boto3.session.Session:
     def init_session():
         global __BOTO3_SESSION__
         __BOTO3_SESSION__ = boto3.session.Session(
@@ -14,6 +14,10 @@ def get_boto3_session(connection: Connection) -> boto3.session.Session:
         )
 
     if not __BOTO3_SESSION__:
+        if connection is None:
+            raise RuntimeError(
+                'A Connection object needs to be passed to initialize the boto3 session for the first time'
+            )
         init_session()
 
     return __BOTO3_SESSION__

--- a/dbt/adapters/athena/session.py
+++ b/dbt/adapters/athena/session.py
@@ -1,0 +1,19 @@
+import boto3.session
+from dbt.contracts.connection import Connection
+
+
+__BOTO3_SESSION__: boto3.session.Session = None
+
+
+def get_boto3_session(connection: Connection) -> boto3.session.Session:
+    def init_session():
+        global __BOTO3_SESSION__
+        __BOTO3_SESSION__ = boto3.session.Session(
+            region_name=connection.credentials.region_name,
+            profile_name=connection.credentials.aws_profile_name,
+        )
+
+    if not __BOTO3_SESSION__:
+        init_session()
+
+    return __BOTO3_SESSION__


### PR DESCRIPTION
This PR is yet another duplicate of #56 #121 #124. Due to the fact that #56 has been lying around for quite some time (outdated version of the code),  #124 addresses the issue in only one instance of the adapter i.e. `clean_up_table`, I decided to go with the approach introduced in #121 by @cstruct and included a global variable that holds the `boto3_session` that can be retrieve at any point in time via `get_boto3_session()`. I would be happy to decline this PR in favour of #121 if preferred as it addresses the the issue at hand.

Thank you in advance. 